### PR TITLE
【WIP】feat: Add rectangle packing algorithm for texture placement

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod export;
 pub mod pack;
 pub mod place;
+pub mod rectpack;
 pub mod texture;

--- a/src/rectpack.rs
+++ b/src/rectpack.rs
@@ -1,0 +1,109 @@
+#[derive(Clone, Copy)]
+pub struct Rectangle {
+    pub left: u32,
+    pub top: u32,
+    pub right: u32,
+    pub bottom: u32,
+}
+
+impl Rectangle {
+    pub fn width(&self) -> u32 {
+        self.right - self.left
+    }
+
+    pub fn height(&self) -> u32 {
+        self.bottom - self.top
+    }
+
+    pub fn fits(&self, img: &Image) -> bool {
+        self.width() >= img.width && self.height() >= img.height
+    }
+
+    pub fn fits_perfectly(&self, img: &Image) -> bool {
+        self.width() == img.width && self.height() == img.height
+    }
+}
+
+pub struct Image {
+    pub id: String,
+    pub width: u32,
+    pub height: u32,
+}
+
+pub struct Node {
+    child: [Option<Box<Node>>; 2],
+    rect: Rectangle,
+    image_id: Option<i32>,
+}
+
+impl Node {
+    pub fn new(rect: Rectangle) -> Self {
+        Node {
+            child: [None, None],
+            rect,
+            image_id: None,
+        }
+    }
+
+    pub fn insert(&mut self, img: &Image) -> Option<&mut Node> {
+        if let Some(ref mut child0) = self.child[0] {
+            if let Some(new_node) = child0.insert(img) {
+                return Some(new_node);
+            }
+        } else {
+            if self.image_id.is_some() {
+                return None;
+            }
+
+            if !self.rect.fits(img) {
+                return None;
+            }
+
+            if self.rect.fits_perfectly(img) {
+                // self.image_id = Some(img.id);
+                return Some(self);
+            }
+
+            let child0_rect;
+            let child1_rect;
+            let dw = self.rect.width() - img.width;
+            let dh = self.rect.height() - img.height;
+
+            if dw > dh {
+                child0_rect = Rectangle {
+                    left: self.rect.left,
+                    top: self.rect.top,
+                    right: self.rect.left + img.width - 1,
+                    bottom: self.rect.bottom,
+                };
+                child1_rect = Rectangle {
+                    left: self.rect.left + img.width,
+                    top: self.rect.top,
+                    right: self.rect.right,
+                    bottom: self.rect.bottom,
+                };
+            } else {
+                child0_rect = Rectangle {
+                    left: self.rect.left,
+                    top: self.rect.top,
+                    right: self.rect.right,
+                    bottom: self.rect.top + img.height - 1,
+                };
+                child1_rect = Rectangle {
+                    left: self.rect.left,
+                    top: self.rect.top + img.height,
+                    right: self.rect.right,
+                    bottom: self.rect.bottom,
+                };
+            }
+
+            self.child[0] = Some(Box::new(Node::new(child0_rect)));
+            self.child[1] = Some(Box::new(Node::new(child1_rect)));
+
+            if let Some(ref mut child0) = self.child[0] {
+                return child0.insert(img);
+            }
+        }
+        None
+    }
+}


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #0

### What I did（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- どのような変更をしますか？ 目的は？ -->

- ...


### Notes（連絡事項）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら手順を簡単に伝えてください。そのほか連絡事項など。 -->

None / なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 新しい`rectpack`モジュールが追加され、矩形パッキングに関連する機能が外部からアクセス可能になりました。
	- `TexturePacker`のコンストラクタが幅と高さのパラメータを受け取るようになり、テクスチャ配置操作のためのルートノードサイズを指定できるようになりました。
	- 画像のメタデータを管理する`Image`構造体が導入され、テクスチャデータの取り扱いが改善されました。

- **変更点**
	- `Node`構造体が追加され、矩形内に画像を効率的に配置するための二分木構造をサポートします。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->