### PR TITLE
テクスチャ集約のためのatlas-packerの処理の流れの変更 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ sys-info = "0.7.0"
 clap = {version = "4.5.9", features = ["derive"] }
 
 [dev-dependencies]
+rand = "0.8.5"
 tempfile = "3.10.1"

--- a/examples/test_pack.rs
+++ b/examples/test_pack.rs
@@ -74,7 +74,7 @@ fn main() {
             polygon.downsample_factor.clone(),
         );
 
-        let _ = packer
+        packer
             .lock()
             .unwrap()
             .add_texture(polygon.id.clone(), cropped_texture);

--- a/examples/test_random_polygon.rs
+++ b/examples/test_random_polygon.rs
@@ -1,3 +1,4 @@
+use std::f64::consts::TAU;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Instant;
@@ -41,7 +42,7 @@ fn main() {
 
             let num_points = rand::random::<usize>() % 10 + 3;
             let mut radians = (0..num_points)
-                .map(|_| random_in_range(0.0, 6.28))
+                .map(|_| random_in_range(0.0, TAU))
                 .collect::<Vec<f64>>();
             radians.sort_by(|a, b| a.total_cmp(b));
 
@@ -90,7 +91,7 @@ fn main() {
             polygon.downsample_factor.clone(),
         );
 
-        let _ = packer
+        packer
             .lock()
             .unwrap()
             .add_texture(polygon.id.clone(), cropped_texture);

--- a/examples/test_random_polygon.rs
+++ b/examples/test_random_polygon.rs
@@ -1,0 +1,120 @@
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::Instant;
+
+use atlas_packer::texture::{CroppedTexture, TextureSizeCache};
+use rayon::prelude::*;
+
+use atlas_packer::{
+    export::JpegAtlasExporter,
+    pack::TexturePacker,
+    place::{GuillotineTexturePlacer, TexturePlacerConfig},
+    texture::{DownsampleFactor, TextureCache},
+};
+
+#[derive(Debug, Clone)]
+struct Polygon {
+    id: String,
+    uv_coords: Vec<(f64, f64)>,
+    texture_uri: PathBuf,
+    downsample_factor: DownsampleFactor,
+}
+
+fn random_in_range(min: f64, max: f64) -> f64 {
+    min + (max - min) * rand::random::<f64>()
+}
+
+fn main() {
+    let all_process_start = Instant::now();
+
+    // 3D Tiles Sink passes the texture path and UV coordinates for each polygon
+    let mut polygons: Vec<Polygon> = Vec::new();
+    let downsample_factor = 1.0;
+    for i in 0..200 {
+        for j in 1..11 {
+            // Specify a polygon to crop around the center of the image
+
+            // generate random polygon
+            let edge_radius = 0.3;
+            let center_x = random_in_range(edge_radius, 1.0 - edge_radius);
+            let center_y = random_in_range(edge_radius, 1.0 - edge_radius);
+
+            let num_points = rand::random::<usize>() % 10 + 3;
+            let mut radians = (0..num_points)
+                .map(|_| random_in_range(0.0, 6.28))
+                .collect::<Vec<f64>>();
+            radians.sort_by(|a, b| a.total_cmp(b));
+
+            let uv_coords = radians
+                .iter()
+                .map(|radian| {
+                    let radius = random_in_range(edge_radius * 0.1, edge_radius);
+                    let x = center_x + radius * radian.cos();
+                    let y = center_y + radius * radian.sin();
+                    (x, y)
+                })
+                .collect::<Vec<(f64, f64)>>();
+
+            let path_string: String = format!("./examples/assets/{}.png", j);
+            let image_path = PathBuf::from(path_string.as_str());
+            polygons.push(Polygon {
+                id: format!("texture_{}_{}", i, j),
+                uv_coords,
+                texture_uri: image_path,
+                downsample_factor: DownsampleFactor::new(&downsample_factor),
+            });
+        }
+    }
+
+    // initialize texture packer
+    let config = TexturePlacerConfig {
+        width: 4096,
+        height: 4096,
+        padding: 0,
+    };
+    let placer = GuillotineTexturePlacer::new(config.clone());
+    let exporter = JpegAtlasExporter::default();
+    let packer = Mutex::new(TexturePacker::new(placer, exporter));
+
+    let packing_start = Instant::now();
+
+    // cache image size
+    let texture_size_cache = TextureSizeCache::new();
+    // place textures on the atlas
+    polygons.par_iter().for_each(|polygon| {
+        let place_start = Instant::now();
+        let texture_size = texture_size_cache.get_or_insert(&polygon.texture_uri);
+        let cropped_texture = CroppedTexture::new(
+            &polygon.texture_uri,
+            texture_size,
+            &polygon.uv_coords,
+            polygon.downsample_factor.clone(),
+        );
+
+        let _ = packer
+            .lock()
+            .unwrap()
+            .add_texture(polygon.id.clone(), cropped_texture);
+        let place_duration = place_start.elapsed();
+        println!("{}, texture place process {:?}", polygon.id, place_duration);
+    });
+
+    let mut packer = packer.into_inner().unwrap();
+
+    packer.finalize();
+
+    let duration = packing_start.elapsed();
+    println!("all packing process {:?}", duration);
+
+    let start = Instant::now();
+
+    // Caches the original textures for exporting to an atlas.
+    let texture_cache = TextureCache::new(100_000_000);
+    let output_dir = Path::new("./examples/output/");
+    packer.export(output_dir, &texture_cache, config.width(), config.height());
+    let duration = start.elapsed();
+    println!("all atlas export process {:?}", duration);
+
+    let duration = all_process_start.elapsed();
+    println!("all process {:?}", duration);
+}

--- a/examples/test_random_polygon.rs
+++ b/examples/test_random_polygon.rs
@@ -2,12 +2,12 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Instant;
 
+use atlas_packer::pack::AtlasPacker;
 use atlas_packer::texture::{CroppedTexture, TextureSizeCache};
 use rayon::prelude::*;
 
 use atlas_packer::{
     export::JpegAtlasExporter,
-    pack::TexturePacker,
     place::{GuillotineTexturePlacer, TexturePlacerConfig},
     texture::{DownsampleFactor, TextureCache},
 };
@@ -72,9 +72,8 @@ fn main() {
         height: 4096,
         padding: 0,
     };
-    let placer = GuillotineTexturePlacer::new(config.clone());
-    let exporter = JpegAtlasExporter::default();
-    let packer = Mutex::new(TexturePacker::new(placer, exporter));
+
+    let packer = Mutex::new(AtlasPacker::default());
 
     let packing_start = Instant::now();
 
@@ -99,9 +98,8 @@ fn main() {
         println!("{}, texture place process {:?}", polygon.id, place_duration);
     });
 
-    let mut packer = packer.into_inner().unwrap();
-
-    packer.finalize();
+    let packer = packer.into_inner().unwrap();
+    let packed = packer.pack(GuillotineTexturePlacer::new(config.clone()));
 
     let duration = packing_start.elapsed();
     println!("all packing process {:?}", duration);
@@ -111,7 +109,14 @@ fn main() {
     // Caches the original textures for exporting to an atlas.
     let texture_cache = TextureCache::new(100_000_000);
     let output_dir = Path::new("./examples/output/");
-    packer.export(output_dir, &texture_cache, config.width(), config.height());
+
+    packed.export(
+        JpegAtlasExporter::default(),
+        output_dir,
+        &texture_cache,
+        config.width(),
+        config.height(),
+    );
     let duration = start.elapsed();
     println!("all atlas export process {:?}", duration);
 

--- a/examples/test_unused_pixels.rs
+++ b/examples/test_unused_pixels.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use atlas_packer::{
     export::PngAtlasExporter,
-    pack::TexturePacker,
+    pack::AtlasPacker,
     place::{GuillotineTexturePlacer, TexturePlacerConfig},
     texture::TextureCache,
 };
@@ -15,12 +15,18 @@ fn main() {
     let texture_cache = TextureCache::new(100_000_000);
 
     let config = TexturePlacerConfig::new(500, 500, 1);
-    let placer = GuillotineTexturePlacer::new(config.clone());
-    let exporter = PngAtlasExporter::default();
-    let packer = TexturePacker::new(placer, exporter);
+
+    let packer = AtlasPacker::default();
+    let packed = packer.pack(GuillotineTexturePlacer::new(config.clone()));
 
     let output_dir = Path::new("examples/output/");
-    packer.export(output_dir, &texture_cache, config.width(), config.height());
+    packed.export(
+        PngAtlasExporter::default(),
+        output_dir,
+        &texture_cache,
+        config.width(),
+        config.height(),
+    );
 
     let (all_pixels, unused_pixels) = unused_pixels::unused_pixels();
 


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #11 

### What I did（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- どのような変更をしますか？ 目的は？ -->

- 処理の流れを変更し、finalize後に初めてUVを取得できるようにする
  - 既存の入出力は変えていない
- テストの追加
  - 新しい処理の流れのほか、様々な形や位置のポリゴンへの対応を検証する

### Notes（連絡事項）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら手順を簡単に伝えてください。そのほか連絡事項など。 -->

- push対象は[texture-clustering-main](https://github.com/MIERUNE/atlas-packer/tree/texture-clustering-main)
- gis-converter側は[texture-clustering-1](https://github.com/MIERUNE/plateau-gis-converter/tree/texture-clustering-1) にて対応、ただし3dtilesのみ対応のため注意
