### PR TITLE
アトラス上で重複する領域を持つテクスチャ同士をクラスタリングする

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ sys-info = "0.7.0"
 clap = {version = "4.5.9", features = ["derive"] }
 
 [dev-dependencies]
+rand = "0.8.5"
 tempfile = "3.10.1"

--- a/examples/test_pack.rs
+++ b/examples/test_pack.rs
@@ -77,7 +77,7 @@ fn main() {
             polygon.downsample_factor.clone(),
         );
 
-        let _ = packer
+        packer
             .lock()
             .unwrap()
             .add_texture(polygon.id.clone(), cropped_texture);

--- a/examples/test_pack.rs
+++ b/examples/test_pack.rs
@@ -2,14 +2,16 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Instant;
 
-use atlas_packer::pack::AtlasPacker;
-use atlas_packer::texture::{CroppedTexture, TextureSizeCache};
 use rayon::prelude::*;
 
 use atlas_packer::{
     export::JpegAtlasExporter,
+    pack::AtlasPacker,
     place::{GuillotineTexturePlacer, TexturePlacerConfig},
-    texture::{DownsampleFactor, TextureCache},
+    texture::{
+        cache::{TextureCache, TextureSizeCache},
+        CroppedTexture, DownsampleFactor,
+    },
 };
 
 #[derive(Debug, Clone)]

--- a/examples/test_pack.rs
+++ b/examples/test_pack.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Instant;
 
+use atlas_packer::texture::PolygonMappedTexture;
 use rayon::prelude::*;
 
 use atlas_packer::{
@@ -10,7 +11,7 @@ use atlas_packer::{
     place::{GuillotineTexturePlacer, TexturePlacerConfig},
     texture::{
         cache::{TextureCache, TextureSizeCache},
-        CroppedTexture, DownsampleFactor,
+        DownsampleFactor,
     },
 };
 
@@ -69,7 +70,7 @@ fn main() {
     polygons.par_iter().for_each(|polygon| {
         let place_start = Instant::now();
         let texture_size = texture_size_cache.get_or_insert(&polygon.texture_uri);
-        let cropped_texture = CroppedTexture::new(
+        let cropped_texture = PolygonMappedTexture::new(
             &polygon.texture_uri,
             texture_size,
             &polygon.uv_coords,

--- a/examples/test_random_polygon.rs
+++ b/examples/test_random_polygon.rs
@@ -64,7 +64,7 @@ fn main() {
 
             let num_points = 5;
             let mut radians = (0..num_points)
-                .map(|_| random_in_range(0.0, 6.28))
+                .map(|_| random_in_range(0.0, std::f64::consts::TAU))
                 .collect::<Vec<f64>>();
 
             radians.sort_by(|a, b| a.total_cmp(b));

--- a/examples/test_random_polygon.rs
+++ b/examples/test_random_polygon.rs
@@ -1,0 +1,120 @@
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::Instant;
+
+use atlas_packer::texture::{CroppedTexture, TextureSizeCache};
+use rayon::prelude::*;
+
+use atlas_packer::{
+    export::JpegAtlasExporter,
+    pack::TexturePacker,
+    place::{GuillotineTexturePlacer, TexturePlacerConfig},
+    texture::{DownsampleFactor, TextureCache},
+};
+
+#[derive(Debug, Clone)]
+struct Polygon {
+    id: String,
+    uv_coords: Vec<(f64, f64)>,
+    texture_uri: PathBuf,
+    downsample_factor: DownsampleFactor,
+}
+
+fn random_in_range(min: f64, max: f64) -> f64 {
+    min + (max - min) * rand::random::<f64>()
+}
+
+fn main() {
+    let all_process_start = Instant::now();
+
+    // 3D Tiles Sink passes the texture path and UV coordinates for each polygon
+    let mut polygons: Vec<Polygon> = Vec::new();
+    let downsample_factor = 1.0;
+    for i in 0..200 {
+        for j in 1..11 {
+            // Specify a polygon to crop around the center of the image
+
+            // generate random polygon
+            let edge_radius = 0.3;
+            let center_x = random_in_range(edge_radius, 1.0 - edge_radius);
+            let center_y = random_in_range(edge_radius, 1.0 - edge_radius);
+
+            let num_points = rand::random::<usize>() % 10 + 3;
+            let mut radians = (0..num_points)
+                .map(|_| random_in_range(0.0, 6.28))
+                .collect::<Vec<f64>>();
+            radians.sort_by(|a, b| a.total_cmp(b));
+
+            let uv_coords = radians
+                .iter()
+                .map(|radian| {
+                    let radius = random_in_range(edge_radius * 0.1, edge_radius);
+                    let x = center_x + radius * radian.cos();
+                    let y = center_y + radius * radian.sin();
+                    (x, y)
+                })
+                .collect::<Vec<(f64, f64)>>();
+
+            let path_string: String = format!("./examples/assets/{}.png", j);
+            let image_path = PathBuf::from(path_string.as_str());
+            polygons.push(Polygon {
+                id: format!("texture_{}_{}", i, j),
+                uv_coords,
+                texture_uri: image_path,
+                downsample_factor: DownsampleFactor::new(&downsample_factor),
+            });
+        }
+    }
+
+    // initialize texture packer
+    let config = TexturePlacerConfig {
+        width: 4096,
+        height: 4096,
+        padding: 0,
+    };
+    let placer = GuillotineTexturePlacer::new(config.clone());
+    let exporter = JpegAtlasExporter::default();
+    let packer = Mutex::new(TexturePacker::new(placer, exporter));
+
+    let packing_start = Instant::now();
+
+    // cache image size
+    let texture_size_cache = TextureSizeCache::new();
+    // place textures on the atlas
+    polygons.par_iter().for_each(|polygon| {
+        let place_start = Instant::now();
+        let texture_size = texture_size_cache.get_or_insert(&polygon.texture_uri);
+        let cropped_texture = CroppedTexture::new(
+            &polygon.texture_uri,
+            texture_size,
+            &polygon.uv_coords,
+            polygon.downsample_factor.clone(),
+        );
+
+        let _ = packer
+            .lock()
+            .unwrap()
+            .add_texture(polygon.id.clone(), cropped_texture);
+        let place_duration = place_start.elapsed();
+        println!("{}, texture place process {:?}", polygon.id, place_duration);
+    });
+
+    let mut packer = packer.into_inner().unwrap();
+
+    packer.finalize();
+
+    let duration = packing_start.elapsed();
+    println!("all packing process {:?}", duration);
+
+    let start = Instant::now();
+
+    // Caches the original textures for exporting to an atlas.
+    let texture_cache = TextureCache::new(100_000_000);
+    let output_dir = Path::new("./examples/output/");
+    packer.export(output_dir, &texture_cache, config.width(), config.height());
+    let duration = start.elapsed();
+    println!("all atlas export process {:?}", duration);
+
+    let duration = all_process_start.elapsed();
+    println!("all process {:?}", duration);
+}

--- a/examples/test_random_polygon.rs
+++ b/examples/test_random_polygon.rs
@@ -2,12 +2,12 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Instant;
 
+use atlas_packer::pack::AtlasPacker;
 use atlas_packer::texture::{CroppedTexture, TextureSizeCache};
 use rayon::prelude::*;
 
 use atlas_packer::{
     export::JpegAtlasExporter,
-    pack::TexturePacker,
     place::{GuillotineTexturePlacer, TexturePlacerConfig},
     texture::{DownsampleFactor, TextureCache},
 };
@@ -72,9 +72,8 @@ fn main() {
         height: 4096,
         padding: 0,
     };
-    let placer = GuillotineTexturePlacer::new(config.clone());
-    let exporter = JpegAtlasExporter::default();
-    let packer = Mutex::new(TexturePacker::new(placer, exporter));
+
+    let packer = Mutex::new(AtlasPacker::default());
 
     let packing_start = Instant::now();
 
@@ -99,9 +98,8 @@ fn main() {
         println!("{}, texture place process {:?}", polygon.id, place_duration);
     });
 
-    let mut packer = packer.into_inner().unwrap();
-
-    packer.finalize();
+    let packer = packer.into_inner().unwrap();
+    let packed = packer.pack(GuillotineTexturePlacer::new(config.clone()));
 
     let duration = packing_start.elapsed();
     println!("all packing process {:?}", duration);
@@ -111,7 +109,14 @@ fn main() {
     // Caches the original textures for exporting to an atlas.
     let texture_cache = TextureCache::new(100_000_000);
     let output_dir = Path::new("./examples/output/");
-    packer.export(output_dir, &texture_cache, config.width(), config.height());
+
+    packed.export(
+        JpegAtlasExporter::default(),
+        output_dir,
+        &texture_cache,
+        config.width(),
+        config.height(),
+    );
     let duration = start.elapsed();
     println!("all atlas export process {:?}", duration);
 

--- a/examples/test_random_polygon.rs
+++ b/examples/test_random_polygon.rs
@@ -2,14 +2,16 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Instant;
 
-use atlas_packer::pack::AtlasPacker;
-use atlas_packer::texture::{CroppedTexture, TextureSizeCache};
 use rayon::prelude::*;
 
 use atlas_packer::{
     export::JpegAtlasExporter,
+    pack::AtlasPacker,
     place::{GuillotineTexturePlacer, TexturePlacerConfig},
-    texture::{DownsampleFactor, TextureCache},
+    texture::{
+        cache::{TextureCache, TextureSizeCache},
+        CroppedTexture, DownsampleFactor,
+    },
 };
 
 #[derive(Debug, Clone)]

--- a/examples/test_random_polygon.rs
+++ b/examples/test_random_polygon.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Instant;
 
+use atlas_packer::texture::PolygonMappedTexture;
 use rayon::prelude::*;
 
 use atlas_packer::{
@@ -10,7 +11,7 @@ use atlas_packer::{
     place::{GuillotineTexturePlacer, TexturePlacerConfig},
     texture::{
         cache::{TextureCache, TextureSizeCache},
-        CroppedTexture, DownsampleFactor,
+        DownsampleFactor,
     },
 };
 
@@ -85,7 +86,7 @@ fn main() {
     polygons.par_iter().for_each(|polygon| {
         let place_start = Instant::now();
         let texture_size = texture_size_cache.get_or_insert(&polygon.texture_uri);
-        let cropped_texture = CroppedTexture::new(
+        let cropped_texture = PolygonMappedTexture::new(
             &polygon.texture_uri,
             texture_size,
             &polygon.uv_coords,

--- a/examples/test_unused_pixels.rs
+++ b/examples/test_unused_pixels.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use atlas_packer::{
     export::PngAtlasExporter,
-    pack::TexturePacker,
+    pack::AtlasPacker,
     place::{GuillotineTexturePlacer, TexturePlacerConfig},
     texture::TextureCache,
 };
@@ -15,12 +15,18 @@ fn main() {
     let texture_cache = TextureCache::new(100_000_000);
 
     let config = TexturePlacerConfig::new(500, 500, 1);
-    let placer = GuillotineTexturePlacer::new(config.clone());
-    let exporter = PngAtlasExporter::default();
-    let packer = TexturePacker::new(placer, exporter);
+
+    let packer = AtlasPacker::default();
+    let packed = packer.pack(GuillotineTexturePlacer::new(config.clone()));
 
     let output_dir = Path::new("examples/output/");
-    packer.export(output_dir, &texture_cache, config.width(), config.height());
+    packed.export(
+        PngAtlasExporter::default(),
+        output_dir,
+        &texture_cache,
+        config.width(),
+        config.height(),
+    );
 
     let (all_pixels, unused_pixels) = unused_pixels::unused_pixels();
 

--- a/examples/test_unused_pixels.rs
+++ b/examples/test_unused_pixels.rs
@@ -6,7 +6,7 @@ use atlas_packer::{
     export::PngAtlasExporter,
     pack::AtlasPacker,
     place::{GuillotineTexturePlacer, TexturePlacerConfig},
-    texture::TextureCache,
+    texture::cache::TextureCache,
 };
 
 use utils::unused_pixels;

--- a/src/disjoint_set.rs
+++ b/src/disjoint_set.rs
@@ -5,7 +5,6 @@ pub struct DisjointSet {
     parent: Vec<usize>,
 }
 
-// TODO (optional): compress the path
 impl DisjointSet {
     pub fn new(num_elements: usize) -> Self {
         DisjointSet {
@@ -27,7 +26,8 @@ impl DisjointSet {
         self.parent[root_x] = root_y;
     }
 
-    pub fn is_same(&self, x: usize, y: usize) -> bool {
+    #[allow(dead_code)]
+    fn is_same(&self, x: usize, y: usize) -> bool {
         self.root(x) == self.root(y)
     }
 

--- a/src/disjoint_set.rs
+++ b/src/disjoint_set.rs
@@ -1,7 +1,7 @@
 /// Very simple disjoint set implementation for clustering cropped textures
 /// - fixed size
 /// - cannot divide the union
-pub(super) struct DisjointSet {
+pub struct DisjointSet {
     parent: Vec<usize>,
 }
 

--- a/src/disjoint_set.rs
+++ b/src/disjoint_set.rs
@@ -1,0 +1,51 @@
+/// Very simple disjoint set implementation for clustering cropped textures
+/// - fixed size
+/// - cannot divide the union
+pub(super) struct DisjointSet {
+    parent: Vec<usize>,
+}
+
+// TODO (optional): compress the path
+impl DisjointSet {
+    pub fn new(num_elements: usize) -> Self {
+        DisjointSet {
+            parent: (0..num_elements).collect(),
+        }
+    }
+
+    pub fn root(&self, x: usize) -> usize {
+        if self.parent[x] == x {
+            x
+        } else {
+            let root = self.root(self.parent[x]);
+            root
+        }
+    }
+
+    pub fn unite(&mut self, x: usize, y: usize) {
+        let root_x = self.root(x);
+        let root_y = self.root(y);
+        self.parent[root_x] = root_y;
+    }
+
+    pub fn is_same(&self, x: usize, y: usize) -> bool {
+        self.root(x) == self.root(y)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_disjoint_set_unite() {
+        let mut ds = DisjointSet::new(5);
+        ds.unite(0, 1);
+        ds.unite(3, 4);
+        ds.unite(1, 2);
+        assert!(ds.is_same(0, 2));
+        assert!(!ds.is_same(0, 3));
+
+        ds.unite(0, 3);
+        assert!(ds.is_same(0, 4));
+    }
+}

--- a/src/disjoint_set.rs
+++ b/src/disjoint_set.rs
@@ -17,8 +17,7 @@ impl DisjointSet {
         if self.parent[x] == x {
             x
         } else {
-            let root = self.root(self.parent[x]);
-            root
+            self.root(self.parent[x])
         }
     }
 
@@ -30,6 +29,10 @@ impl DisjointSet {
 
     pub fn is_same(&self, x: usize, y: usize) -> bool {
         self.root(x) == self.root(y)
+    }
+
+    pub fn compress(&mut self) {
+        self.parent = self.parent.iter().map(|&x| self.root(x)).collect();
     }
 }
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -6,7 +6,8 @@ use image::{ImageBuffer, ImageFormat, Rgb, Rgba};
 use rayon::prelude::*;
 
 use crate::place::PlacedTextureInfo;
-use crate::texture::{CroppedTexture, TextureCache};
+use crate::texture::cache::TextureCache;
+use crate::texture::CroppedTexture;
 
 pub trait AtlasExporter: Sync + Send {
     fn export(

--- a/src/export.rs
+++ b/src/export.rs
@@ -5,15 +5,16 @@ use hashbrown::HashMap;
 use image::{ImageBuffer, ImageFormat, Rgb, Rgba};
 use rayon::prelude::*;
 
-use crate::place::PlacedTextureInfo;
-use crate::texture::cache::TextureCache;
-use crate::texture::CroppedTexture;
+use crate::{
+    place::PlacedTextureGeometry,
+    texture::{cache::TextureCache, ToplevelTexture},
+};
 
 pub trait AtlasExporter: Sync + Send {
     fn export(
         &self,
-        atlas_data: &[PlacedTextureInfo],
-        textures: &HashMap<String, CroppedTexture>,
+        atlas_data: &[PlacedTextureGeometry],
+        textures: &HashMap<String, ToplevelTexture>,
         output_path: &Path,
         texture_cache: &TextureCache,
         width: u32,
@@ -48,8 +49,8 @@ impl AtlasExporter for WebpAtlasExporter {
 
     fn export(
         &self,
-        atlas_data: &[PlacedTextureInfo],
-        textures: &HashMap<String, CroppedTexture>,
+        atlas_data: &[PlacedTextureGeometry],
+        textures: &HashMap<String, ToplevelTexture>,
         output_path: &Path,
         texture_cache: &TextureCache,
         width: u32,
@@ -87,8 +88,8 @@ impl AtlasExporter for PngAtlasExporter {
 
     fn export(
         &self,
-        atlas_data: &[PlacedTextureInfo],
-        textures: &HashMap<String, CroppedTexture>,
+        atlas_data: &[PlacedTextureGeometry],
+        textures: &HashMap<String, ToplevelTexture>,
         output_path: &Path,
         texture_cache: &TextureCache,
         width: u32,
@@ -126,8 +127,8 @@ impl AtlasExporter for JpegAtlasExporter {
 
     fn export(
         &self,
-        atlas_data: &[PlacedTextureInfo],
-        textures: &HashMap<String, CroppedTexture>,
+        atlas_data: &[PlacedTextureGeometry],
+        textures: &HashMap<String, ToplevelTexture>,
         output_path: &Path,
         texture_cache: &TextureCache,
         width: u32,
@@ -143,8 +144,8 @@ impl AtlasExporter for JpegAtlasExporter {
 }
 
 fn create_atlas_image(
-    atlas_data: &[PlacedTextureInfo],
-    textures: &HashMap<String, CroppedTexture>,
+    atlas_data: &[PlacedTextureGeometry],
+    textures: &HashMap<String, ToplevelTexture>,
     texture_cache: &TextureCache,
     width: u32,
     height: u32,
@@ -152,7 +153,7 @@ fn create_atlas_image(
     let atlas_image = Mutex::new(ImageBuffer::new(width, height));
 
     atlas_data.par_iter().for_each(|info| {
-        let texture = textures.get(&info.id).unwrap();
+        let texture = textures.get(&info.cluster_id).unwrap();
         let cropped = texture.crop(&texture_cache.get_image(&texture.image_path));
         let image = cropped.as_rgba8().unwrap();
 
@@ -168,8 +169,8 @@ fn create_atlas_image(
 }
 
 fn create_atlas_image_jpeg(
-    atlas_data: &[PlacedTextureInfo],
-    textures: &HashMap<String, CroppedTexture>,
+    atlas_data: &[PlacedTextureGeometry],
+    textures: &HashMap<String, ToplevelTexture>,
     texture_cache: &TextureCache,
     width: u32,
     height: u32,
@@ -177,7 +178,7 @@ fn create_atlas_image_jpeg(
     let atlas_image = Mutex::new(ImageBuffer::new(width, height));
 
     atlas_data.par_iter().for_each(|info| {
-        let texture = textures.get(&info.id).unwrap();
+        let texture = textures.get(&info.cluster_id).unwrap();
         let cropped = texture.crop(&texture_cache.get_image(&texture.image_path));
         let image = cropped.to_rgb8();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod disjoint_set;
 pub mod export;
 pub mod pack;
 pub mod place;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub mod disjoint_set;
+mod disjoint_set;
 pub mod export;
 pub mod pack;
 pub mod place;

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -1,11 +1,12 @@
 use std::path::Path;
 
 use hashbrown::HashMap;
-use rayon::{prelude::*, vec};
+use rayon::prelude::*;
 
 use crate::export::AtlasExporter;
 use crate::place::{PlacedTextureInfo, TexturePlacer};
-use crate::texture::{CroppedTexture, TextureCache};
+use crate::texture::cache::TextureCache;
+use crate::texture::CroppedTexture;
 
 pub type Atlas = Vec<PlacedTextureInfo>;
 

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -57,29 +57,28 @@ impl AtlasPacker {
 
         // cluster id -> texture ids
         let mut cluster_id_map: HashMap<String, Vec<String>> = HashMap::new();
-        for i in 0..texture_ids.len() {
+        for (i, texture_id) in texture_ids.iter().enumerate() {
             let cluster_id = disjoint_set.root(i).to_string();
-            let texture_id = texture_ids[i].clone();
             cluster_id_map
                 .entry(cluster_id.to_string())
                 .or_insert_with(Vec::new)
-                .push(texture_id);
+                .push(texture_id.clone());
         }
 
         // create toplevel textures
         let cluster_map = cluster_id_map
             .iter()
             .filter_map(|(cluster_id, texture_ids)| {
-                let toplevel_texture = texture_ids
-                    .iter()
-                    .fold(None, |acc: Option<ToplevelTexture>, texture_id| {
-                        let texture = self.textures.get(texture_id).unwrap();
-                        match acc {
-                            Some(toplevel_texture) => toplevel_texture.expand(texture),
-                            None => Some(ToplevelTexture::new(texture)),
-                        }
-                    })
-                    .unwrap();
+                let toplevel_texture =
+                    texture_ids
+                        .iter()
+                        .fold(None, |acc: Option<ToplevelTexture>, texture_id| {
+                            let texture = self.textures.get(texture_id).unwrap();
+                            match acc {
+                                Some(toplevel_texture) => toplevel_texture.expand(texture),
+                                None => Some(ToplevelTexture::new(texture)),
+                            }
+                        })?;
 
                 let children = texture_ids
                     .iter()

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -35,33 +35,22 @@ impl AtlasPacker {
 
         for (texture_id, texture) in self.textures.iter() {
             let (atlas_id, atlas_index) = {
-                let current_atlas_id = atlases.len();
-
-                if placer.can_place(texture) {
-                    let texture_info = placer.place_texture(
-                        (texture, texture_id),
-                        vec![(texture, texture_id)],
-                        current_atlas_id.to_string().as_ref(),
-                    );
-                    let first_info = texture_info.1.get(0).unwrap().clone().unwrap();
-                    current_atlas.push(first_info);
-                    (current_atlas_id.to_string(), current_atlas.len() - 1)
-                } else {
+                if !placer.can_place(texture) {
+                    let current_atlas_id = atlases.len();
                     atlases.insert(current_atlas_id.to_string(), current_atlas.clone());
                     current_atlas.clear();
                     placer.reset_param();
-
-                    let current_atlas_id = atlases.len();
-
-                    let texture_info = placer.place_texture(
-                        (texture, texture_id),
-                        vec![(texture, texture_id)],
-                        current_atlas_id.to_string().as_ref(),
-                    );
-                    let first_info = texture_info.1.get(0).unwrap().clone().unwrap();
-                    current_atlas.push(first_info);
-                    (current_atlas_id.to_string(), current_atlas.len() - 1)
                 }
+
+                let current_atlas_id: usize = atlases.len();
+                let texture_info = placer.place_texture(
+                    (texture, texture_id),
+                    vec![(texture, texture_id)],
+                    current_atlas_id.to_string().as_ref(),
+                );
+                let first_info = texture_info.1.get(0).unwrap().clone().unwrap();
+                current_atlas.push(first_info);
+                (current_atlas_id.to_string(), current_atlas.len() - 1)
             };
             texture_info_map.insert(texture_id.clone(), (atlas_id, atlas_index));
         }

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -117,6 +117,7 @@ impl AtlasPacker {
             }
 
             let current_atlas_id = atlases.len().to_string();
+
             let (toplevel_texture_info, children_texture_infos) = placer.place_texture(
                 cluster.toplevel_texture.clone(),
                 cluster.children.clone(),
@@ -153,9 +154,10 @@ impl AtlasPacker {
 }
 
 pub struct PackedAtlasProvider {
-    clusters: HashMap<String, Cluster>,
     // atlas id -> atlas
     atlases: HashMap<String, Atlas>,
+    // cluster id -> cluster
+    clusters: HashMap<String, Cluster>,
     // texture id -> placed texture info
     texture_info_map: HashMap<String, PlacedPolygonUVCoords>,
 }

--- a/src/place.rs
+++ b/src/place.rs
@@ -260,7 +260,6 @@ impl TexturePlacer for GuillotineTexturePlacer {
                 .iter()
                 .map(|(children_texture, children_texture_id)| {
                     let offset = if let Some(offset) = toplevel_texture.covers(children_texture) {
-                        println!("offset: {:?}", offset);
                         offset
                     } else {
                         return None;

--- a/src/texture/cache.rs
+++ b/src/texture/cache.rs
@@ -1,0 +1,104 @@
+use std::path::PathBuf;
+
+use image::DynamicImage;
+use stretto::Cache;
+use sys_info::mem_info;
+
+use super::utils::get_image_size;
+
+// Cache for storing the only size of the image
+pub struct TextureSizeCache {
+    cache: Cache<PathBuf, (u32, u32)>,
+}
+
+impl TextureSizeCache {
+    pub fn new() -> Self {
+        TextureSizeCache {
+            cache: Cache::new(1_000_000, 1_000_000).unwrap(),
+        }
+    }
+
+    pub fn get_or_insert(&self, image_path: &PathBuf) -> (u32, u32) {
+        match self.cache.get(image_path) {
+            Some(size) => *size.value(),
+            None => {
+                let size = get_image_size(image_path).unwrap();
+                // Since it only retains the size of the texture, set the cost to 1 for everything.
+                let cost = 1;
+                self.cache.insert(image_path.to_path_buf(), size, cost);
+                self.cache.wait().unwrap();
+
+                size
+            }
+        }
+    }
+}
+
+impl Default for TextureSizeCache {
+    fn default() -> Self {
+        TextureSizeCache::new()
+    }
+}
+
+impl Drop for TextureSizeCache {
+    fn drop(&mut self) {
+        self.cache.close().unwrap();
+    }
+}
+
+// Cache for storing the image
+pub struct TextureCache {
+    cache: Cache<PathBuf, DynamicImage>,
+}
+
+impl TextureCache {
+    pub fn new(capacity: usize) -> Self {
+        let default_capacity = get_cache_size().unwrap();
+        if capacity == 0 {
+            TextureCache {
+                cache: Cache::new(default_capacity, 2_000_000_000).unwrap(),
+            }
+        } else {
+            TextureCache {
+                cache: Cache::new(capacity, 2_000_000_000).unwrap(),
+            }
+        }
+    }
+
+    pub fn get_image(&self, path: &PathBuf) -> DynamicImage {
+        match self.cache.get(path) {
+            Some(image) => image.value().clone(),
+            None => {
+                let image = image::open(path).expect("Failed to open image file");
+                let cost = image.width() * image.height() * image.color().bytes_per_pixel() as u32;
+                self.cache
+                    .insert(path.to_path_buf(), image.clone(), cost as i64);
+                self.cache.wait().unwrap();
+
+                image
+            }
+        }
+    }
+}
+
+fn get_cache_size() -> Result<usize, String> {
+    const MIN_CACHE_SIZE: usize = 100 * 1024 * 1024; // 100MB
+    const MAX_CACHE_SIZE: usize = 2 * 1024 * 1024 * 1024; // 2GB
+
+    match mem_info() {
+        Ok(mem) => {
+            let total_memory = mem.total as usize * 1024;
+            // 15% of total memory
+            let cache_size = (total_memory as f64 * 0.15) as usize;
+            Ok(cache_size.clamp(MIN_CACHE_SIZE, MAX_CACHE_SIZE))
+        }
+
+        Err(e) => Err(format!("Failed to retrieve memory information.: {}", e)),
+    }
+}
+
+impl Drop for TextureCache {
+    fn drop(&mut self) {
+        self.cache.close().unwrap();
+    }
+}

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -3,10 +3,12 @@ use std::{
     sync::mpsc,
 };
 
-use image::{DynamicImage, GenericImageView, ImageBuffer, ImageReader};
+use image::{DynamicImage, GenericImageView, ImageBuffer};
 use rayon::prelude::*;
-use stretto::Cache;
-use sys_info::mem_info;
+use utils::{calc_bbox, uv_to_pixel_coords};
+
+pub mod cache;
+mod utils;
 
 #[derive(Debug, Clone)]
 pub struct DownsampleFactor(f32);
@@ -22,103 +24,6 @@ impl DownsampleFactor {
 
     pub fn value(&self) -> f32 {
         self.0
-    }
-}
-
-// Cache for storing the only size of the image
-pub struct TextureSizeCache {
-    cache: Cache<PathBuf, (u32, u32)>,
-}
-
-impl TextureSizeCache {
-    pub fn new() -> Self {
-        TextureSizeCache {
-            cache: Cache::new(1_000_000, 1_000_000).unwrap(),
-        }
-    }
-
-    pub fn get_or_insert(&self, image_path: &PathBuf) -> (u32, u32) {
-        match self.cache.get(image_path) {
-            Some(size) => *size.value(),
-            None => {
-                let size = get_image_size(image_path).unwrap();
-                // Since it only retains the size of the texture, set the cost to 1 for everything.
-                let cost = 1;
-                self.cache.insert(image_path.to_path_buf(), size, cost);
-                self.cache.wait().unwrap();
-
-                size
-            }
-        }
-    }
-}
-
-impl Default for TextureSizeCache {
-    fn default() -> Self {
-        TextureSizeCache::new()
-    }
-}
-
-impl Drop for TextureSizeCache {
-    fn drop(&mut self) {
-        self.cache.close().unwrap();
-    }
-}
-
-// Cache for storing the image
-pub struct TextureCache {
-    cache: Cache<PathBuf, DynamicImage>,
-}
-
-impl TextureCache {
-    pub fn new(capacity: usize) -> Self {
-        let default_capacity = get_cache_size().unwrap();
-        if capacity == 0 {
-            TextureCache {
-                cache: Cache::new(default_capacity, 2_000_000_000).unwrap(),
-            }
-        } else {
-            TextureCache {
-                cache: Cache::new(capacity, 2_000_000_000).unwrap(),
-            }
-        }
-    }
-
-    pub fn get_image(&self, path: &PathBuf) -> DynamicImage {
-        match self.cache.get(path) {
-            Some(image) => image.value().clone(),
-            None => {
-                let image = image::open(path).expect("Failed to open image file");
-                let cost = image.width() * image.height() * image.color().bytes_per_pixel() as u32;
-                self.cache
-                    .insert(path.to_path_buf(), image.clone(), cost as i64);
-                self.cache.wait().unwrap();
-
-                image
-            }
-        }
-    }
-}
-
-fn get_cache_size() -> Result<usize, String> {
-    const MIN_CACHE_SIZE: usize = 100 * 1024 * 1024; // 100MB
-    const MAX_CACHE_SIZE: usize = 2 * 1024 * 1024 * 1024; // 2GB
-
-    match mem_info() {
-        Ok(mem) => {
-            let total_memory = mem.total as usize * 1024;
-            // 15% of total memory
-            let cache_size = (total_memory as f64 * 0.15) as usize;
-            Ok(cache_size.clamp(MIN_CACHE_SIZE, MAX_CACHE_SIZE))
-        }
-
-        Err(e) => Err(format!("Failed to retrieve memory information.: {}", e)),
-    }
-}
-
-impl Drop for TextureCache {
-    fn drop(&mut self) {
-        self.cache.close().unwrap();
     }
 }
 
@@ -293,33 +198,4 @@ fn is_point_inside_polygon(test_point: (f64, f64), polygon: &[(f64, f64)]) -> bo
     }
 
     is_inside
-}
-
-// utils
-
-fn get_image_size<P: AsRef<Path>>(file_path: P) -> Result<(u32, u32), image::ImageError> {
-    let reader = ImageReader::open(file_path)?;
-    let dimensions = reader.into_dimensions()?;
-    Ok(dimensions)
-}
-
-fn uv_to_pixel_coords(uv_coords: &[(f64, f64)], width: u32, height: u32) -> Vec<(u32, u32)> {
-    uv_coords
-        .iter()
-        .map(|(u, v)| {
-            (
-                (u.clamp(0.0, 1.0) * width as f64).min(width as f64 - 1.0) as u32,
-                ((1.0 - v.clamp(0.0, 1.0)) * height as f64).min(height as f64 - 1.0) as u32,
-            )
-        })
-        .collect()
-}
-
-fn calc_bbox(pixel_coords: &[(u32, u32)]) -> (u32, u32, u32, u32) {
-    pixel_coords.iter().fold(
-        (u32::MAX, u32::MAX, 0, 0),
-        |(min_x, min_y, max_x, max_y), (x, y)| {
-            (min_x.min(*x), min_y.min(*y), max_x.max(*x), max_y.max(*y))
-        },
-    )
 }

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1,10 +1,6 @@
-use std::{
-    path::{Path, PathBuf},
-    sync::mpsc,
-};
+use std::path::{Path, PathBuf};
 
 use image::{DynamicImage, GenericImageView, ImageBuffer};
-use rayon::prelude::*;
 use utils::{calc_bbox, uv_to_pixel_coords};
 
 pub mod cache;
@@ -152,6 +148,8 @@ impl ToplevelTexture {
         // Collect pixels into a Vec and then process in parallel
         let pixels: Vec<_> = cropped_image.enumerate_pixels().collect();
 
+        // TODO: Crop pixels that are not contained in the polygon
+        /*
         let samples = 1;
         let num_threads = rayon::current_num_threads();
         let chunk_size = (pixels.len() / num_threads).clamp(1, pixels.len() + 1);
@@ -178,13 +176,10 @@ impl ToplevelTexture {
                             let center_x = x + 0.5 / self.width() as f64;
                             let center_y = y - 0.5 / self.height() as f64;
 
-                            // TODO !!!
-                            if
-                            /*is_point_inside_polygon(
+                            if is_point_inside_polygon(
                                 (center_x, center_y),
                                 &self.cropped_uv_coords,
-                            )*/
-                            true {
+                            ) {
                                 is_inside = true;
                                 break 'subpixels;
                             }
@@ -202,12 +197,18 @@ impl ToplevelTexture {
                 s.send(local_results).unwrap();
             });
 
+
         // Collect results in the main thread
         let mut clipped = ImageBuffer::new(self.width(), self.height());
         for received in receiver {
             for (px, py, pixel) in received {
                 clipped.put_pixel(px, py, pixel);
             }
+        }
+        */
+        let mut clipped = ImageBuffer::new(self.width(), self.height());
+        for &(px, py, pixel) in &pixels {
+            clipped.put_pixel(px, py, *pixel);
         }
 
         // Downsample

--- a/src/texture/utils.rs
+++ b/src/texture/utils.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use image::ImageReader;
 
+#[allow(dead_code)]
 pub fn is_point_inside_polygon(test_point: (f64, f64), polygon: &[(f64, f64)]) -> bool {
     let mut is_inside = false;
     let mut previous_vertex_index = polygon.len() - 1;

--- a/src/texture/utils.rs
+++ b/src/texture/utils.rs
@@ -1,0 +1,30 @@
+use std::path::Path;
+
+use image::ImageReader;
+
+pub fn get_image_size<P: AsRef<Path>>(file_path: P) -> Result<(u32, u32), image::ImageError> {
+    let reader = ImageReader::open(file_path)?;
+    let dimensions = reader.into_dimensions()?;
+    Ok(dimensions)
+}
+
+pub fn uv_to_pixel_coords(uv_coords: &[(f64, f64)], width: u32, height: u32) -> Vec<(u32, u32)> {
+    uv_coords
+        .iter()
+        .map(|(u, v)| {
+            (
+                (u.clamp(0.0, 1.0) * width as f64).min(width as f64 - 1.0) as u32,
+                ((1.0 - v.clamp(0.0, 1.0)) * height as f64).min(height as f64 - 1.0) as u32,
+            )
+        })
+        .collect()
+}
+
+pub fn calc_bbox(pixel_coords: &[(u32, u32)]) -> (u32, u32, u32, u32) {
+    pixel_coords.iter().fold(
+        (u32::MAX, u32::MAX, 0, 0),
+        |(min_x, min_y, max_x, max_y), (x, y)| {
+            (min_x.min(*x), min_y.min(*y), max_x.max(*x), max_y.max(*y))
+        },
+    )
+}

--- a/src/texture/utils.rs
+++ b/src/texture/utils.rs
@@ -2,6 +2,29 @@ use std::path::Path;
 
 use image::ImageReader;
 
+pub fn is_point_inside_polygon(test_point: (f64, f64), polygon: &[(f64, f64)]) -> bool {
+    let mut is_inside = false;
+    let mut previous_vertex_index = polygon.len() - 1;
+
+    for current_vertex_index in 0..polygon.len() {
+        let (current_x, current_y) = polygon[current_vertex_index];
+        let (previous_x, previous_y) = polygon[previous_vertex_index];
+
+        let is_y_between_vertices = (current_y > test_point.1) != (previous_y > test_point.1);
+        let does_ray_intersect = test_point.0
+            < (previous_x - current_x) * (test_point.1 - current_y) / (previous_y - current_y)
+                + current_x;
+
+        if is_y_between_vertices && does_ray_intersect {
+            is_inside = !is_inside;
+        }
+
+        previous_vertex_index = current_vertex_index;
+    }
+
+    is_inside
+}
+
 pub fn get_image_size<P: AsRef<Path>>(file_path: P) -> Result<(u32, u32), image::ImageError> {
     let reader = ImageReader::open(file_path)?;
     let dimensions = reader.into_dimensions()?;


### PR DESCRIPTION
<!-- Close or Related Issues -->

### What I did（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- どのような変更をしますか？ 目的は？ -->

- 以下のような不要な領域を除去するため、アトラス化時にテクスチャをクラスタリングする
  - 標識や壁など、同じテクスチャ領域が、モデル上で何度も使いまわされる場合がある
    - 壁、床、窓、柱、標識など
  - テクスチャアトラス上に使用回数ぶん重複して記録されると、大量のアトラスが生成されるため、アトラス上に1つだけ記録されるとベスト

### Notes（連絡事項）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら手順を簡単に伝えてください。そのほか連絡事項など。 -->

None / なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - `TexturePacker`が`AtlasPacker`に置き換えられ、テクスチャパッキングのプロセスが改善されました。
  - 新しいファイル`test_random_polygon.rs`が追加され、ランダムポリゴンの生成とテクスチャのエクスポート機能が実装されました。
  - 新しいモジュール`disjoint_set`が追加され、テクスチャのクラスタリング機能が導入されました。

- **バグ修正**
  - テクスチャのエクスポート機能が更新され、パッキング結果に基づいてエクスポートが行われるようになりました。

- **リファクタリング**
  - テクスチャの配置ロジックが再構築され、より階層的なアプローチが採用されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->