### PR TITLE
using rtree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ stretto = "0.8.4"
 rayon = "1.10.0"
 sys-info = "0.7.0"
 clap = {version = "4.5.9", features = ["derive"] }
+rstar = "0.12.0"
+
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/src/disjoint_set.rs
+++ b/src/disjoint_set.rs
@@ -12,6 +12,7 @@ impl DisjointSet {
         }
     }
 
+    #[inline]
     pub fn root(&self, x: usize) -> usize {
         if self.parent[x] == x {
             x
@@ -20,6 +21,7 @@ impl DisjointSet {
         }
     }
 
+    #[inline]
     pub fn unite(&mut self, x: usize, y: usize) {
         let root_x = self.root(x);
         let root_y = self.root(y);
@@ -31,6 +33,7 @@ impl DisjointSet {
         self.root(x) == self.root(y)
     }
 
+    #[inline]
     pub fn compress(&mut self) {
         self.parent = self.parent.iter().map(|&x| self.root(x)).collect();
     }

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use hashbrown::HashMap;
 use rayon::prelude::*;
+use rstar::{RTree, RTreeObject, AABB};
 
 use crate::disjoint_set::DisjointSet;
 use crate::export::AtlasExporter;
@@ -29,6 +30,22 @@ pub(super) struct Cluster {
     pub uv_polygons: Vec<(PolygonID, ChildUVPolygon)>,
 }
 
+struct Rectangle {
+    index: usize,
+    min_x: f32,
+    min_y: f32,
+    max_x: f32,
+    max_y: f32,
+}
+
+impl RTreeObject for Rectangle {
+    type Envelope = AABB<[f32; 2]>;
+
+    fn envelope(&self) -> Self::Envelope {
+        AABB::from_corners([self.min_x, self.min_y], [self.max_x, self.max_y])
+    }
+}
+
 impl AtlasPacker {
     pub fn add_texture(&mut self, polygon_id: PolygonID, texture: PolygonMappedTexture) {
         self.textures.insert(polygon_id, texture);
@@ -37,22 +54,43 @@ impl AtlasPacker {
     fn create_clusters(&self) -> HashMap<ClusterID, Cluster> {
         let polygon_ids: Vec<PolygonID> = self.textures.keys().cloned().collect();
 
-        let disjoint_set = {
-            let mut disjoint_set = DisjointSet::new(polygon_ids.len());
+        let mut rtree = RTree::new();
+        let mut disjoint_set = DisjointSet::new(polygon_ids.len());
 
-            for i in 0..polygon_ids.len() {
-                for j in (i + 1)..polygon_ids.len() {
-                    let texture_i = self.textures.get(&polygon_ids[i]).unwrap();
-                    let texture_j = self.textures.get(&polygon_ids[j]).unwrap();
+        for (i, polygon_id) in polygon_ids.iter().enumerate() {
+            let texture = self.textures.get(polygon_id).unwrap();
+            let (min_x, min_y, max_x, max_y) = texture.bbox();
+            let texture_with_index = Rectangle {
+                index: i,
+                min_x: min_x as f32,
+                min_y: min_y as f32,
+                max_x: max_x as f32,
+                max_y: max_y as f32,
+            };
+            rtree.insert(texture_with_index);
+        }
+        for (i, polygon_id) in polygon_ids.iter().enumerate() {
+            let texture = self.textures.get(polygon_id).unwrap();
+            let bbox = AABB::from_corners(
+                [texture.bbox().0 as f32, texture.bbox().1 as f32],
+                [texture.bbox().2 as f32, texture.bbox().3 as f32],
+            );
 
-                    if texture_i.bbox_overlaps(texture_j) {
-                        disjoint_set.unite(i, j);
-                    }
+            // Only items with the same texture and overlapping areas will be searched
+            let hit = rtree
+                .locate_in_envelope_intersecting(&bbox)
+                .filter(|target| {
+                    let target_texture = self.textures.get(&polygon_ids[target.index]).unwrap();
+                    texture.image_path == target_texture.image_path
+                });
+
+            for j in hit {
+                if i < j.index {
+                    disjoint_set.unite(i, j.index);
                 }
             }
-            disjoint_set.compress();
-            disjoint_set
-        };
+        }
+        disjoint_set.compress();
 
         let clustered_polygon_ids: HashMap<ClusterID, Vec<PolygonID>> = {
             let mut clustered_polygon_ids = HashMap::new();

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -49,6 +49,12 @@ impl PolygonMappedTexture {
         }
     }
 
+    #[inline]
+    pub fn bbox(&self) -> (u32, u32, u32, u32) {
+        calc_bbox(&self.pixel_coords)
+    }
+
+    #[allow(dead_code)]
     pub fn bbox_overlaps(&self, other: &Self) -> bool {
         if self.image_path != other.image_path {
             return false;

--- a/src/texture/utils.rs
+++ b/src/texture/utils.rs
@@ -44,6 +44,7 @@ pub fn uv_to_pixel_coords(uv_coords: &[(f64, f64)], width: u32, height: u32) -> 
         .collect()
 }
 
+#[inline]
 pub fn calc_bbox(pixel_coords: &[(u32, u32)]) -> (u32, u32, u32, u32) {
     pixel_coords.iter().fold(
         (u32::MAX, u32::MAX, 0, 0),


### PR DESCRIPTION
<!-- Close or Related Issues -->

### What I did（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- どのような変更をしますか？ 目的は？ -->

- クラスターの作成時にRTreeを利用するように変更
- 一部、頻繁に利用される小さい関数をインライン化

### Notes（連絡事項）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら手順を簡単に伝えてください。そのほか連絡事項など。 -->

None / なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - `Rectangle`構造体を追加し、テクスチャのバウンディングボックスを効率的に処理するためにRツリーを使用するように`create_clusters`メソッドを最適化しました。
  - `PolygonMappedTexture`に新しい`bbox`メソッドを追加し、ピクセル座標に基づいてバウンディングボックスを計算します。

- **パフォーマンス向上**
  - `DisjointSet`の主要メソッドにインライン属性を追加し、パフォーマンスを向上させました。
  - `calc_bbox`関数にもインライン属性を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->