### PR TITLE
Compress webp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ rayon = "1.10.0"
 sys-info = "0.7.0"
 clap = {version = "4.5.9", features = ["derive"] }
 rstar = "0.12.0"
+webp = "0.3.0"
 
 
 [dev-dependencies]

--- a/examples/test_pack.rs
+++ b/examples/test_pack.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Instant;
 
+use atlas_packer::export::WebpAtlasExporter;
 use atlas_packer::texture::PolygonMappedTexture;
 use rayon::prelude::*;
 
@@ -97,7 +98,7 @@ fn main() {
     let texture_cache = TextureCache::new(100_000_000);
     let output_dir = Path::new("./examples/output/");
     packed.export(
-        JpegAtlasExporter::default(),
+        WebpAtlasExporter::default(),
         output_dir,
         &texture_cache,
         config.width(),


### PR DESCRIPTION
<!-- Close or Related Issues -->

### What I did（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- どのような変更をしますか？ 目的は？ -->

- webpを不可逆圧縮で利用
- 品質は75パーセントに設定（JEPGと同程度の品質）

### Notes（連絡事項）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら手順を簡単に伝えてください。そのほか連絡事項など。 -->

None / なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - テクスチャアトラスのエクスポート機能が強化され、JPEGからWebP形式への変更が行われました。
  - 画像処理の能力が向上し、異なる画像フォーマットとエンコーディング技術が利用可能になりました。

- **バグ修正**
  - エクスポートメソッドの改善により、画像の保存と処理がより効率的になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->