### PR TITLE
与えられたUV座標の範囲が0の時に、アトラスに1×1の領域を確保する

### DIFF
--- a/examples/test_pack.rs
+++ b/examples/test_pack.rs
@@ -96,13 +96,15 @@ fn main() {
     // Caches the original textures for exporting to an atlas.
     let texture_cache = TextureCache::new(100_000_000);
     let output_dir = Path::new("./examples/output/");
-    packed.export(
-        WebpAtlasExporter::default(),
-        output_dir,
-        &texture_cache,
-        config.width(),
-        config.height(),
-    );
+    packed
+        .export(
+            WebpAtlasExporter::default(),
+            output_dir,
+            &texture_cache,
+            config.width(),
+            config.height(),
+        )
+        .expect("Failed to export atlas");
     let duration = start.elapsed();
     println!("all atlas export process {:?}", duration);
 

--- a/examples/test_random_polygon.rs
+++ b/examples/test_random_polygon.rs
@@ -124,13 +124,15 @@ fn main() {
     let texture_cache = TextureCache::new(100_000_000);
     let output_dir = Path::new("./examples/output/");
 
-    packed.export(
-        JpegAtlasExporter::default(),
-        output_dir,
-        &texture_cache,
-        config.width(),
-        config.height(),
-    );
+    packed
+        .export(
+            JpegAtlasExporter::default(),
+            output_dir,
+            &texture_cache,
+            config.width(),
+            config.height(),
+        )
+        .expect("Failed to export atlas");
     let mut count = 0;
     let count_limit = 20;
     polygons.iter().for_each(|polygon| {

--- a/examples/test_unused_pixels.rs
+++ b/examples/test_unused_pixels.rs
@@ -20,13 +20,15 @@ fn main() {
     let packed = packer.pack(GuillotineTexturePlacer::new(config.clone()));
 
     let output_dir = Path::new("examples/output/");
-    packed.export(
-        PngAtlasExporter::default(),
-        output_dir,
-        &texture_cache,
-        config.width(),
-        config.height(),
-    );
+    packed
+        .export(
+            PngAtlasExporter::default(),
+            output_dir,
+            &texture_cache,
+            config.width(),
+            config.height(),
+        )
+        .expect("Failed to export atlas");
 
     let (all_pixels, unused_pixels) = unused_pixels::unused_pixels();
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -4,12 +4,31 @@ use std::sync::Mutex;
 use hashbrown::HashMap;
 use image::{DynamicImage, ImageBuffer, ImageFormat, Rgb, Rgba};
 use rayon::prelude::*;
+use thiserror::Error;
 
 use crate::{
     place::PlacedTextureGeometry,
     texture::{cache::TextureCache, ClusterBoundingTexture},
     ClusterID,
 };
+
+#[derive(Error, Debug)]
+pub enum ExportError {
+    #[error("Image error: {0}")]
+    ImageError(#[from] image::ImageError),
+
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("WebP encoding failed: {0}")]
+    WebpError(String),
+
+    #[error("Texture not found for cluster: {0}")]
+    TextureNotFound(String),
+
+    #[error("Failed to convert image to expected format for cluster: {0}")]
+    ImageConversionError(String),
+}
 
 pub trait AtlasExporter: Sync + Send {
     fn export(
@@ -20,7 +39,7 @@ pub trait AtlasExporter: Sync + Send {
         texture_cache: &TextureCache,
         width: u32,
         height: u32,
-    );
+    ) -> Result<(), ExportError>;
 
     fn get_extension(&self) -> &str;
     fn get_image_format(&self) -> ImageFormat;
@@ -56,14 +75,16 @@ impl AtlasExporter for WebpAtlasExporter {
         texture_cache: &TextureCache,
         width: u32,
         height: u32,
-    ) {
+    ) -> Result<(), ExportError> {
         let output_path = output_path.with_extension(self.get_extension());
 
-        let atlas_image = create_atlas_rgba(atlas_data, textures, texture_cache, width, height);
+        let atlas_image = create_atlas_rgba(atlas_data, textures, texture_cache, width, height)?;
         let binding = DynamicImage::ImageRgba8(atlas_image);
-        let webp_encoder = webp::Encoder::from_image(&binding).unwrap();
+        let webp_encoder = webp::Encoder::from_image(&binding)
+            .map_err(|e| ExportError::WebpError(e.to_string()))?;
         let webp = webp_encoder.encode(75.0);
-        std::fs::write(output_path, &*webp).unwrap();
+        std::fs::write(output_path, &*webp)?;
+        Ok(())
     }
 }
 
@@ -97,12 +118,11 @@ impl AtlasExporter for PngAtlasExporter {
         texture_cache: &TextureCache,
         width: u32,
         height: u32,
-    ) {
-        let atlas_image = create_atlas_rgba(atlas_data, textures, texture_cache, width, height);
+    ) -> Result<(), ExportError> {
+        let atlas_image = create_atlas_rgba(atlas_data, textures, texture_cache, width, height)?;
         let output_path = output_path.with_extension(self.get_extension());
-        atlas_image
-            .save_with_format(output_path, self.get_image_format())
-            .unwrap();
+        atlas_image.save_with_format(output_path, self.get_image_format())?;
+        Ok(())
     }
 }
 
@@ -136,13 +156,12 @@ impl AtlasExporter for JpegAtlasExporter {
         texture_cache: &TextureCache,
         width: u32,
         height: u32,
-    ) {
+    ) -> Result<(), ExportError> {
         let atlas_image =
-            create_atlas_image_rgb(atlas_data, textures, texture_cache, width, height);
+            create_atlas_image_rgb(atlas_data, textures, texture_cache, width, height)?;
         let output_path = output_path.with_extension(self.get_extension());
-        atlas_image
-            .save_with_format(output_path, self.get_image_format())
-            .unwrap();
+        atlas_image.save_with_format(output_path, self.get_image_format())?;
+        Ok(())
     }
 }
 
@@ -152,23 +171,30 @@ fn create_atlas_rgba(
     texture_cache: &TextureCache,
     width: u32,
     height: u32,
-) -> ImageBuffer<Rgba<u8>, Vec<u8>> {
+) -> Result<ImageBuffer<Rgba<u8>, Vec<u8>>, ExportError> {
     let atlas_image = Mutex::new(ImageBuffer::new(width, height));
 
-    atlas_data.par_iter().for_each(|info| {
-        let texture = textures.get(&info.cluster_id).unwrap();
-        let cropped = texture.crop(&texture_cache.get_image(&texture.image_path));
-        let image = cropped.as_rgba8().unwrap();
+    atlas_data
+        .par_iter()
+        .try_for_each(|info| -> Result<(), ExportError> {
+            let texture = textures
+                .get(&info.cluster_id)
+                .ok_or_else(|| ExportError::TextureNotFound(info.cluster_id.clone()))?;
+            let cropped = texture.crop(&texture_cache.get_image(&texture.image_path));
+            let image = cropped
+                .as_rgba8()
+                .ok_or_else(|| ExportError::ImageConversionError(info.cluster_id.clone()))?;
 
-        let mut atlas_image = atlas_image.lock().unwrap();
-        for (x, y, pixel) in image.enumerate_pixels() {
-            let atlas_x = info.origin.0 + x;
-            let atlas_y = info.origin.1 + y;
-            atlas_image.put_pixel(atlas_x, atlas_y, *pixel);
-        }
-    });
+            let mut atlas_image = atlas_image.lock().unwrap();
+            for (x, y, pixel) in image.enumerate_pixels() {
+                let atlas_x = info.origin.0 + x;
+                let atlas_y = info.origin.1 + y;
+                atlas_image.put_pixel(atlas_x, atlas_y, *pixel);
+            }
+            Ok(())
+        })?;
 
-    atlas_image.into_inner().unwrap()
+    Ok(atlas_image.into_inner().unwrap())
 }
 
 fn create_atlas_image_rgb(
@@ -177,21 +203,26 @@ fn create_atlas_image_rgb(
     texture_cache: &TextureCache,
     width: u32,
     height: u32,
-) -> ImageBuffer<Rgb<u8>, Vec<u8>> {
+) -> Result<ImageBuffer<Rgb<u8>, Vec<u8>>, ExportError> {
     let atlas_image = Mutex::new(ImageBuffer::new(width, height));
 
-    atlas_data.par_iter().for_each(|info| {
-        let texture = textures.get(&info.cluster_id).unwrap();
-        let cropped = texture.crop(&texture_cache.get_image(&texture.image_path));
-        let image = cropped.to_rgb8();
+    atlas_data
+        .par_iter()
+        .try_for_each(|info| -> Result<(), ExportError> {
+            let texture = textures
+                .get(&info.cluster_id)
+                .ok_or_else(|| ExportError::TextureNotFound(info.cluster_id.clone()))?;
+            let cropped = texture.crop(&texture_cache.get_image(&texture.image_path));
+            let image = cropped.to_rgb8();
 
-        let mut atlas_image = atlas_image.lock().unwrap();
-        for (x, y, pixel) in image.enumerate_pixels() {
-            let atlas_x = info.origin.0 + x;
-            let atlas_y = info.origin.1 + y;
-            atlas_image.put_pixel(atlas_x, atlas_y, *pixel);
-        }
-    });
+            let mut atlas_image = atlas_image.lock().unwrap();
+            for (x, y, pixel) in image.enumerate_pixels() {
+                let atlas_x = info.origin.0 + x;
+                let atlas_y = info.origin.1 + y;
+                atlas_image.put_pixel(atlas_x, atlas_y, *pixel);
+            }
+            Ok(())
+        })?;
 
-    atlas_image.into_inner().unwrap()
+    Ok(atlas_image.into_inner().unwrap())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ pub mod pack;
 pub mod place;
 pub mod texture;
 
+pub use export::ExportError;
+
 pub type ClusterID = String;
 pub type AtlasID = usize;
 pub type PolygonID = String;

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -5,7 +5,7 @@ use rayon::prelude::*;
 use rstar::{RTree, RTreeObject, AABB};
 
 use crate::disjoint_set::DisjointSet;
-use crate::export::AtlasExporter;
+use crate::export::{AtlasExporter, ExportError};
 use crate::place::{PlacedTextureGeometry, PlacedUVPolygon, TexturePlacer};
 use crate::texture::cache::TextureCache;
 use crate::texture::{ChildUVPolygon, ClusterBoundingTexture, PolygonMappedTexture};
@@ -209,8 +209,8 @@ impl PackedAtlasProvider {
         texture_cache: &TextureCache,
         width: u32,
         height: u32,
-    ) {
-        self.atlases.par_iter().for_each(|(id, atlas)| {
+    ) -> Result<(), ExportError> {
+        self.atlases.par_iter().try_for_each(|(id, atlas)| {
             let output_path = output_dir.join(id.to_string());
             exporter.export(
                 atlas,
@@ -223,8 +223,8 @@ impl PackedAtlasProvider {
                 texture_cache,
                 width,
                 height,
-            );
-        });
+            )
+        })
     }
 
     pub fn get_texture_info(&self, polygon_id: &PolygonID) -> Option<&PlacedUVPolygon> {

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -241,9 +241,11 @@ impl ClusterBoundingTexture {
             clipped.put_pixel(px, py, *pixel);
         }
 
-        // Downsample
-        let scaled_width = (clipped.width() as f32 * self.downsample_factor.value()) as u32;
-        let scaled_height = (clipped.height() as f32 * self.downsample_factor.value()) as u32;
+        // Downsample (ensure at least 1×1 to avoid zero-dimension images)
+        let scaled_width =
+            (clipped.width() as f32 * self.downsample_factor.value()).max(1.0) as u32;
+        let scaled_height =
+            (clipped.height() as f32 * self.downsample_factor.value()).max(1.0) as u32;
 
         DynamicImage::ImageRgba8(image::imageops::resize(
             &clipped,


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #0

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

  1. calc_bbox が min == max を返す → crop_width = 0, crop_height = 0
  2. buffer = 2 なので get_buffered_geometry() → buffered_width = 4, buffered_height = 4
  3. crop() のダウンサンプル: (4 * downsample_factor) as u32 → downsample_factorが小さいと 0 になる
  4. image::imageops::resize に 0×0 が渡される
  5. WebPエンコーダが VP8_ENC_ERROR_BAD_DIMENSION でpanic

  place.rs の scale_dimensions() には .max(1.0) ガードがあるのに、crop() には同じガードがないという不整合が直接の原因。

  加えて、export() が戻り値なし (→ ()) で全箇所 unwrap() しているため、想定外のエラーが全てpanicになり、呼び出し側で制御できなかった。

### Notes
<!-- If manual testing is required, please describe the procedure. -->

